### PR TITLE
fix task name, filter suspendable/resumable tasks, add ssl verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You will need to set the following environment variables
   to admin
 * **PASSWORD** - The password for the above user
 * **TZ** - Times default to GMT without a timezone e.g. Australia/Sydney
+* **VERIFY_SSL** - Set to false to skip SSL host verificaiton. 
 
 You can then control start and stop in two ways, first by setting an hour of the
 day

--- a/hyper
+++ b/hyper
@@ -7,8 +7,11 @@ class Backup
   include HTTParty
   format :json
 
-  def initialize(dsm, username, password)
+  def initialize(dsm, username, password, verify_ssl = true)
     self.class.base_uri dsm
+    if !verify_ssl
+      self.class.default_options.update(verify: false)
+    end
     @sid = login(username, password)
   end
 
@@ -41,6 +44,7 @@ class Backup
 
   def tasks
     params = {
+      additional: '["last_bkp_result"]',
       api: 'SYNO.Backup.Task',
       version: 1,
       method: 'list',
@@ -89,13 +93,14 @@ start_hour = ENV['START_HOUR']
 end_hour = ENV['END_HOUR']
 start_cron = ENV['START_CRON'] || "0 #{start_hour} * * *"
 end_cron = ENV['END_CRON'] || "0 #{end_hour} * * *"
+verify_ssl = !(ENV['VERIFY_SSL'] == 'false')
 
 puts "Connecting to #{dsm}"
 puts "Start Cron: #{start_cron}"
 puts "End Cron: #{end_cron}"
 puts "Current time: #{Time.now}"
 
-backup = Backup.new(dsm, username, password)
+backup = Backup.new(dsm, username, password, verify_ssl)
 
 scheduler = Rufus::Scheduler.new
 
@@ -103,9 +108,10 @@ scheduler.cron(start_cron) do
   puts 'Resuming backup tasks'
 
   tasks = backup.tasks
+  tasks = tasks.select {|t| t['last_bkp_result'] == 'suspend' }
 
   tasks.each do |task|
-    puts "resuming #{task['task_name']}"
+    puts "resuming #{task['name']}"
     response = backup.resume task['task_id']
     puts response
   end
@@ -114,9 +120,10 @@ end
 scheduler.cron(end_cron) do
   puts 'Suspending backup tasks'
   tasks = backup.tasks
+  tasks = tasks.select {|t| t['last_bkp_result'] == 'backingup' }
 
   tasks.each do |task|
-    puts "suspending #{task['task_name']}"
+    puts "suspending #{task['name']}"
     response = backup.suspend task['task_id']
     puts response
   end


### PR DESCRIPTION
Hi,

Thanks for a great solution for handling my lengthy hyper backup tasks. 

This PR contains 2 fixes and 1 new feature: 

#### Fix 1:
Field 'task_name' was changed to 'name' in Synology API. Fix reflects that change.

#### Fix 2:
When having multiple tasks, resuming and later suspending a completed task results in the tasks state rendered as failure. I therefore implemented a filter in cron methods to filter, to resume only suspended tasks and to suspend only running task. 

#### Feature 1: 
Added option to skip SSL verify to cover the use-case case of accessing the DSM by local ip address and having HTTP->HTTPS redirect enabled.

If you would be so kind to rebuild the docker image with the changes above, i would be extremely grateful. 

Cheers, 
Tomas 